### PR TITLE
Match generated output to HLS specifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,12 @@ module.exports = m3u
 const isString = s => typeof s === 'string'
 const isObject = o => o && typeof o === 'object'
 
+/**
+ * See [HTTP Live Streaming
+ * specifications](https://tools.ietf.org/html/rfc8216#section-4.2) The value
+ * types of `RESOLUTION` (`decimal-resolution`) and `FRAME-RATE`
+ * (`decimal-floating-point`) must not be "quoted".
+ */
 const keysToExcludeFormatting = ["RESOLUTION", "FRAME-RATE"];
 const excludeKeyFromFormatting = key => key && keysToExcludeFormatting.includes(key);
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ module.exports = m3u
 const isString = s => typeof s === 'string'
 const isObject = o => o && typeof o === 'object'
 
+const keysToExcludeFormatting = ["RESOLUTION", "FRAME_RATE"];
+const excludeKeyFromFormatting = key => key && keysToExcludeFormatting.includes(key);
+
 function m3u(obj) {
   if (!Array.isArray(obj)) {
     throw new TypeError('expected array of objects')
@@ -52,5 +55,10 @@ function formatValue(s) {
 }
 
 function formatChildObj(o) {
-  return Object.keys(o).map(key => key.toUpperCase() + '=' + formatValue(o[key])).join(',')
+  return Object.keys(o).map(key => {
+    const upKey = key.toUpperCase();
+    const value = o[key];
+    const formattedValue = excludeKeyFromFormatting(upKey) ? value : formatValue(value)
+    return  upKey + '=' + formattedValue;
+  }).join(',')
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = m3u
 const isString = s => typeof s === 'string'
 const isObject = o => o && typeof o === 'object'
 
-const keysToExcludeFormatting = ["RESOLUTION", "FRAME_RATE"];
+const keysToExcludeFormatting = ["RESOLUTION", "FRAME-RATE"];
 const excludeKeyFromFormatting = key => key && keysToExcludeFormatting.includes(key);
 
 function m3u(obj) {

--- a/test.js
+++ b/test.js
@@ -32,11 +32,11 @@ test('objects', function (t) {
 })
 
 
-test('excludes keys "RESOLUTION" and "FRAME_RATE"', function (t) {
-  const expected = `#EXTM3U\n#EXT-X-LIST:RESOLUTION=1920x1080,FRAME_RATE=30.000,PARAM3="value"`
+test('excludes keys "RESOLUTION" and "FRAME-RATE"', function (t) {
+  const expected = `#EXTM3U\n#EXT-X-LIST:RESOLUTION=1920x1080,FRAME-RATE=30.000,PARAM3="value"`
   t.equal(m3u([ {list: {
     resolution:"1920x1080",
-    frame_rate: "30.000",
+    "frame-rate": "30.000",
     param3: "value"
   }} ]), expected)
   t.end()

--- a/test.js
+++ b/test.js
@@ -30,3 +30,14 @@ test('objects', function (t) {
   }} ]), expected)
   t.end()
 })
+
+
+test('excludes keys "RESOLUTION" and "FRAME_RATE"', function (t) {
+  const expected = `#EXTM3U\n#EXT-X-LIST:RESOLUTION=1920x1080,FRAME_RATE=30.000,PARAM3="value"`
+  t.equal(m3u([ {list: {
+    resolution:"1920x1080",
+    frame_rate: "30.000",
+    param3: "value"
+  }} ]), expected)
+  t.end()
+})


### PR DESCRIPTION
The generated output for some of the attributes (`RESOLUTION` and `FRAME-RATE`) do not match the [HLS specifications](https://tools.ietf.org/html/rfc8216#section-4.2).

```
Output:
#EXT-X-STREAM-INF:...RESOLUTION="1920x1080",FRAME-RATE="30.000",...

Expected:
#EXT-X-STREAM-INF:...RESOLUTION=1920x1080,FRAME-RATE=30.000,...
```

The generated output fails validation by Apple's [`mediastreamvalidator` tool](https://developer.apple.com/documentation/http_live_streaming/about_apple_s_http_live_streaming_tools). Here are some of the errors reported by this tool:

>  frame rate: Illegal character '"' after decimal number

> vertical resolution:Illegal characters after integer

> Could not parse resolution